### PR TITLE
fix: synchronize `yiiActiveForm` `validated` state before triggering `afterValidate` during submit validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore: update documentation and configuration for jQuery integration layer, transitioning from `yii2-framework/core` to `yii2`.
 - docs: update documentation with improved formatting and remove outdated development guide.
 - feat: add dual compatibility for jQuery `3.7` and `4.0` while keeping jQuery `3.7` as the default dependency.
+- fix: synchronize `yiiActiveForm` `validated` state before triggering `afterValidate` during submit validation.

--- a/src/assets/yii.activeForm.js
+++ b/src/assets/yii.activeForm.js
@@ -897,6 +897,10 @@
       submitting,
     );
 
+    if (submitting) {
+      data.validated = errorAttributes.length === 0;
+    }
+
     $form.trigger(events.afterValidate, [messages, errorAttributes]);
 
     if (submitting) {

--- a/tests/js/tests/yii.activeForm.test.js
+++ b/tests/js/tests/yii.activeForm.test.js
@@ -134,7 +134,8 @@ describe("yii.activeForm", function () {
             },
           ])
           .on("afterValidate", function () {
-            validatedInAfterValidate = $activeForm.data("yiiActiveForm").validated;
+            validatedInAfterValidate =
+              $activeForm.data("yiiActiveForm").validated;
           });
 
         $activeForm.yiiActiveForm("validate", true);
@@ -159,7 +160,8 @@ describe("yii.activeForm", function () {
             },
           ])
           .on("afterValidate", function () {
-            validatedInAfterValidate = $activeForm.data("yiiActiveForm").validated;
+            validatedInAfterValidate =
+              $activeForm.data("yiiActiveForm").validated;
           });
 
         $activeForm.yiiActiveForm("validate", true);

--- a/tests/js/tests/yii.activeForm.test.js
+++ b/tests/js/tests/yii.activeForm.test.js
@@ -119,6 +119,53 @@ describe("yii.activeForm", function () {
         // https://github.com/yiisoft/yii2/issues/14186
         assert.isTrue(afterValidateSpy.calledOnce);
       });
+
+      it("should provide validated=true in afterValidate when submit validation has no errors", function () {
+        var inputId = "name";
+        var validatedInAfterValidate = null;
+
+        $activeForm = $("#w0");
+        $activeForm.yiiActiveForm("destroy");
+        $activeForm
+          .yiiActiveForm([
+            {
+              id: inputId,
+              input: "#" + inputId,
+            },
+          ])
+          .on("afterValidate", function () {
+            validatedInAfterValidate = $activeForm.data("yiiActiveForm").validated;
+          });
+
+        $activeForm.yiiActiveForm("validate", true);
+
+        assert.isTrue(validatedInAfterValidate);
+      });
+
+      it("should provide validated=false in afterValidate when submit validation has errors", function () {
+        var inputId = "name";
+        var validatedInAfterValidate = null;
+
+        $activeForm = $("#w0");
+        $activeForm.yiiActiveForm("destroy");
+        $activeForm
+          .yiiActiveForm([
+            {
+              id: inputId,
+              input: "#" + inputId,
+              validate: function (attribute, value, messages) {
+                messages.push("Name cannot be blank.");
+              },
+            },
+          ])
+          .on("afterValidate", function () {
+            validatedInAfterValidate = $activeForm.data("yiiActiveForm").validated;
+          });
+
+        $activeForm.yiiActiveForm("validate", true);
+
+        assert.isFalse(validatedInAfterValidate);
+      });
     });
 
     describe("with disabled fields", function () {


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
