### PR TITLE
fix: include triggering attribute metadata in per-field `yiiActiveForm` Ajax validation requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs: update documentation with improved formatting and remove outdated development guide.
 - feat: add dual compatibility for jQuery `3.7` and `4.0` while keeping jQuery `3.7` as the default dependency.
 - fix: synchronize `yiiActiveForm` `validated` state before triggering `afterValidate` during submit validation.
+- fix: include triggering attribute metadata in per-field `yiiActiveForm` Ajax validation requests.

--- a/src/assets/yii.activeForm.js
+++ b/src/assets/yii.activeForm.js
@@ -292,10 +292,11 @@
     deferreds,
     needAjaxValidation,
     submitting,
+    validationTarget,
   ) {
     removeEmptyMessages(messages);
     if (shouldRunAjaxValidation(data, messages, needAjaxValidation)) {
-      sendAjaxValidation($form, data, messages, submitting);
+      sendAjaxValidation($form, data, messages, submitting, validationTarget);
       return;
     }
 
@@ -314,7 +315,13 @@
     return needAjaxValidation && ($.isEmptyObject(messages) || data.submitting);
   };
 
-  var sendAjaxValidation = function ($form, data, messages, submitting) {
+  var sendAjaxValidation = function (
+    $form,
+    data,
+    messages,
+    submitting,
+    validationTarget,
+  ) {
     $.ajax({
       url: data.settings.validationUrl,
       type: $form.attr("method"),
@@ -324,6 +331,7 @@
           $form,
           data.submitObject,
           data.settings.ajaxParam,
+          validationTarget,
         ),
       dataType: data.settings.ajaxDataType,
       complete: function (jqXHR, textStatus) {
@@ -349,10 +357,36 @@
     });
   };
 
-  var buildAjaxValidationData = function ($form, $button, ajaxParamName) {
+  var appendDataParam = function (data, name, value) {
+    if (value === undefined) {
+      return data;
+    }
+
+    return data + "&" + name + "=" + value;
+  };
+
+  var buildAjaxValidationData = function (
+    $form,
+    $button,
+    ajaxParamName,
+    validationTarget,
+  ) {
     var data = "&" + ajaxParamName + "=" + $form.attr("id");
+    if (validationTarget) {
+      data = appendDataParam(
+        data,
+        ajaxParamName + "_attribute",
+        validationTarget.name,
+      );
+      data = appendDataParam(
+        data,
+        ajaxParamName + "_attribute_id",
+        validationTarget.id,
+      );
+    }
+
     if ($button && $button.length && $button.attr("name")) {
-      data += "&" + $button.attr("name") + "=" + $button.attr("value");
+      data = appendDataParam(data, $button.attr("name"), $button.attr("value"));
     }
 
     return data;
@@ -393,6 +427,17 @@
     updateInputs($form, messages, submitting);
   };
 
+  var consumeValidationTarget = function (data, submitting) {
+    var validationTarget = null;
+    if (!submitting) {
+      validationTarget = data.validationTarget || null;
+    }
+
+    data.validationTarget = null;
+
+    return validationTarget;
+  };
+
   var methods = {
     init: function (attributes, options) {
       return this.each(function () {
@@ -420,6 +465,7 @@
           attributes: attributes,
           submitting: false,
           validated: false,
+          validationTarget: null,
           validate_only: false, // validate without auto submitting
           options: getFormOptions($form),
         });
@@ -522,7 +568,8 @@
         needAjaxValidation = false,
         messages = {},
         deferreds = deferredArray(),
-        submitting = data.submitting;
+        submitting = data.submitting,
+        validationTarget = consumeValidationTarget(data, submitting);
 
       if (submitting) {
         var event = $.Event(events.beforeValidate);
@@ -551,6 +598,7 @@
           deferreds,
           needAjaxValidation,
           submitting,
+          validationTarget,
         );
       });
     },
@@ -577,6 +625,7 @@
         if (data.settings.timer !== undefined) {
           clearTimeout(data.settings.timer);
         }
+        data.validationTarget = null;
         data.submitting = true;
         methods.validate.call($form);
         return false;
@@ -730,6 +779,11 @@
     if (!forceValidate) {
       return;
     }
+
+    data.validationTarget = {
+      id: attribute.id,
+      name: attribute.name,
+    };
 
     cancelActiveValidation(data);
     data.settings.timer = window.setTimeout(

--- a/src/assets/yii.activeForm.js
+++ b/src/assets/yii.activeForm.js
@@ -363,11 +363,7 @@
     }
 
     return (
-      data +
-      "&" +
-      encodeURIComponent(name) +
-      "=" +
-      encodeURIComponent(value)
+      data + "&" + encodeURIComponent(name) + "=" + encodeURIComponent(value)
     );
   };
 

--- a/src/assets/yii.activeForm.js
+++ b/src/assets/yii.activeForm.js
@@ -357,12 +357,18 @@
     });
   };
 
-  var appendDataParam = function (data, name, value) {
-    if (value === undefined) {
+  var appendDataParam = function (data, name, value, includeUndefined) {
+    if (value === undefined && !includeUndefined) {
       return data;
     }
 
-    return data + "&" + name + "=" + value;
+    return (
+      data +
+      "&" +
+      encodeURIComponent(name) +
+      "=" +
+      encodeURIComponent(value)
+    );
   };
 
   var buildAjaxValidationData = function (
@@ -386,7 +392,12 @@
     }
 
     if ($button && $button.length && $button.attr("name")) {
-      data = appendDataParam(data, $button.attr("name"), $button.attr("value"));
+      data = appendDataParam(
+        data,
+        $button.attr("name"),
+        $button.attr("value"),
+        true,
+      );
     }
 
     return data;

--- a/tests/js/tests/yii.activeForm.test.js
+++ b/tests/js/tests/yii.activeForm.test.js
@@ -349,6 +349,116 @@ describe("yii.activeForm", function () {
           }
         });
       });
+
+      describe("with per-field ajax validation metadata", function () {
+        it("should send triggering attribute name and id for validateAttribute ajax requests", function () {
+          $activeForm = $("#w4");
+          $activeForm.yiiActiveForm("destroy");
+          $activeForm.yiiActiveForm(
+            [
+              {
+                id: "test-att1",
+                name: "Test[att1]",
+                input: "#test-att1",
+                container: ".field-test-att1",
+                enableAjaxValidation: true,
+              },
+              {
+                id: "test-att2",
+                name: "Test[att2]",
+                input: "#test-att2",
+                container: ".field-test-att2",
+                enableAjaxValidation: true,
+              },
+            ],
+            {
+              validationUrl: "",
+              errorCssClass: "has-error",
+              successCssClass: "has-success",
+            },
+          );
+
+          var requests = [];
+          function fakeAjax(object) {
+            var jqXHR = {
+              abort: function () {},
+              getResponseHeader: function () {
+                return null;
+              },
+            };
+
+            requests.push(object.data);
+            object.beforeSend(jqXHR, "");
+            object.success({});
+            object.complete(jqXHR, "success");
+          }
+
+          var ajaxStub = sinon.stub($, "ajax", fakeAjax);
+          try {
+            $activeForm.yiiActiveForm("validateAttribute", "test-att1");
+
+            assert.strictEqual(requests.length, 1);
+            assert.include(requests[0], "&ajax=w4");
+            assert.include(requests[0], "&ajax_attribute=Test[att1]");
+            assert.include(requests[0], "&ajax_attribute_id=test-att1");
+          } finally {
+            ajaxStub.restore();
+          }
+        });
+
+        it("should not send triggering attribute metadata for submit validation ajax requests", function () {
+          $activeForm = $("#w4");
+          $activeForm.yiiActiveForm("destroy");
+          $activeForm.yiiActiveForm(
+            [
+              {
+                id: "test-att1",
+                name: "Test[att1]",
+                input: "#test-att1",
+                container: ".field-test-att1",
+                enableAjaxValidation: true,
+              },
+            ],
+            {
+              validationUrl: "",
+              errorCssClass: "has-error",
+              successCssClass: "has-success",
+            },
+          );
+          $activeForm.data("yiiActiveForm").validate_only = true;
+          $activeForm.data("yiiActiveForm").validationTarget = {
+            id: "test-att1",
+            name: "Test[att1]",
+          };
+
+          var requests = [];
+          function fakeAjax(object) {
+            var jqXHR = {
+              abort: function () {},
+              getResponseHeader: function () {
+                return null;
+              },
+            };
+
+            requests.push(object.data);
+            object.beforeSend(jqXHR, "");
+            object.success({});
+            object.complete(jqXHR, "success");
+          }
+
+          var ajaxStub = sinon.stub($, "ajax", fakeAjax);
+          try {
+            $activeForm.yiiActiveForm("validate", true);
+
+            assert.strictEqual(requests.length, 1);
+            assert.include(requests[0], "&ajax=w4");
+            assert.notInclude(requests[0], "ajax_attribute=");
+            assert.notInclude(requests[0], "ajax_attribute_id=");
+          } finally {
+            ajaxStub.restore();
+          }
+        });
+      });
     });
 
     describe("with conditional validation", function () {

--- a/tests/js/tests/yii.activeForm.test.js
+++ b/tests/js/tests/yii.activeForm.test.js
@@ -426,7 +426,9 @@ describe("yii.activeForm", function () {
             },
           );
 
-          var $submitButton = $('<button type="submit" name="scenario"></button>');
+          var $submitButton = $(
+            '<button type="submit" name="scenario"></button>',
+          );
           $activeForm.append($submitButton);
           $activeForm.data("yiiActiveForm").submitObject = $submitButton;
 

--- a/tests/js/tests/yii.activeForm.test.js
+++ b/tests/js/tests/yii.activeForm.test.js
@@ -399,8 +399,58 @@ describe("yii.activeForm", function () {
 
             assert.strictEqual(requests.length, 1);
             assert.include(requests[0], "&ajax=w4");
-            assert.include(requests[0], "&ajax_attribute=Test[att1]");
+            assert.include(requests[0], "&ajax_attribute=Test%5Batt1%5D");
             assert.include(requests[0], "&ajax_attribute_id=test-att1");
+          } finally {
+            ajaxStub.restore();
+          }
+        });
+
+        it("should keep submit button parameter when submit button has no value attribute", function () {
+          $activeForm = $("#w4");
+          $activeForm.yiiActiveForm("destroy");
+          $activeForm.yiiActiveForm(
+            [
+              {
+                id: "test-att1",
+                name: "Test[att1]",
+                input: "#test-att1",
+                container: ".field-test-att1",
+                enableAjaxValidation: true,
+              },
+            ],
+            {
+              validationUrl: "",
+              errorCssClass: "has-error",
+              successCssClass: "has-success",
+            },
+          );
+
+          var $submitButton = $('<button type="submit" name="scenario"></button>');
+          $activeForm.append($submitButton);
+          $activeForm.data("yiiActiveForm").submitObject = $submitButton;
+
+          var requests = [];
+          function fakeAjax(object) {
+            var jqXHR = {
+              abort: function () {},
+              getResponseHeader: function () {
+                return null;
+              },
+            };
+
+            requests.push(object.data);
+            object.beforeSend(jqXHR, "");
+            object.success({});
+            object.complete(jqXHR, "success");
+          }
+
+          var ajaxStub = sinon.stub($, "ajax", fakeAjax);
+          try {
+            $activeForm.yiiActiveForm("validateAttribute", "test-att1");
+
+            assert.strictEqual(requests.length, 1);
+            assert.include(requests[0], "&scenario=undefined");
           } finally {
             ajaxStub.restore();
           }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
