### PR TITLE
feat: allow `yii.js` `handleAction` to use `data-href` with `data-method` when `href` is missing or invalid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add dual compatibility for jQuery `3.7` and `4.0` while keeping jQuery `3.7` as the default dependency.
 - fix: synchronize `yiiActiveForm` `validated` state before triggering `afterValidate` during submit validation.
 - fix: include triggering attribute metadata in per-field `yiiActiveForm` Ajax validation requests.
+- feat: allow `yii.js` `handleAction` to use `data-href` with `data-method` when `href` is missing or invalid.

--- a/src/assets/yii.js
+++ b/src/assets/yii.js
@@ -122,6 +122,7 @@ window.yii = (function ($) {
      * For hyperlinks, the form action will take the value of the "href" attribute of the link.
      * For other elements, either the containing form action or the current page URL will be used
      * as the form action URL.
+     * If `href` is missing or invalid, `data-href` is used as form action URL when `data-method` is set.
      *
      * If the `data-method` attribute is not defined, the `href` attribute (if any) of the element
      * will be assigned to `window.location`.
@@ -161,6 +162,7 @@ window.yii = (function ($) {
         return;
       }
 
+      resolveActionWithDataHref(context);
       handleActionWithMethod(context);
     },
 
@@ -237,19 +239,36 @@ window.yii = (function ($) {
       ? $("#" + $e.attr("data-form"))
       : $e.closest("form");
     var params = $e.data("params");
+    var action = $e.attr("href");
 
     return {
       $e: $e,
       event: event,
       $form: $form,
       method: $e.data("method"),
-      action: $e.attr("href"),
-      isValidAction: $e.attr("href") && $e.attr("href") !== "#",
+      action: action,
+      isValidAction: isValidAction(action),
       params: params,
       areValidParams: params && $.isPlainObject(params),
       usePjax: isPjaxEnabled($e),
       pjaxOptions: {},
     };
+  }
+
+  function resolveActionWithDataHref(context) {
+    if (context.isValidAction) {
+      return;
+    }
+
+    var dataHref = context.$e.data("href");
+    if (isValidAction(dataHref)) {
+      context.action = dataHref;
+      context.isValidAction = true;
+    }
+  }
+
+  function isValidAction(action) {
+    return action && action !== "#";
   }
 
   function isPjaxEnabled($e) {

--- a/tests/js/data/yii.html
+++ b/tests/js/data/yii.html
@@ -37,6 +37,11 @@
                             class="submit-form-not-exist"
                             data-form="not-existing-form"
                         ></button>
+                        <button
+                            class="button-data-href"
+                            type="button"
+                            data-href="/tests/index"
+                        ></button>
 
                         <input
                             class="not-submit-no-form-pjax"
@@ -201,6 +206,13 @@
                         data-method="put"
                         data-params='{"foo":"1","bar":"2"}'
                     ></a>
+                    <button
+                        class="post-data-href"
+                        type="button"
+                        data-method="post"
+                        data-href="/tests/index"
+                        data-params='{"foo":"1","bar":"2"}'
+                    ></button>
 
                     <a
                         class="get-params-pjax"
@@ -229,6 +241,14 @@
                     <a
                         class="bad-action-new-method"
                         href="#"
+                        data-method="post"
+                        data-form="method-form"
+                        data-params='{"foo":"1","bar":"2"}'
+                    ></a>
+                    <a
+                        class="bad-href-data-href-new-method"
+                        href="#"
+                        data-href="/tests/index"
                         data-method="post"
                         data-form="method-form"
                         data-params='{"foo":"1","bar":"2"}'

--- a/tests/js/tests/yii.test.js
+++ b/tests/js/tests/yii.test.js
@@ -522,6 +522,7 @@ describe("yii", function () {
               "submit, data-form, form does not exist": [
                 ".submit-form-not-exist",
               ],
+              "button, data-href, no data-method": [".button-data-href"],
               "not submit, no form, data-pjax": [".not-submit-no-form-pjax"],
               "submit, no form, data-pjax": [".submit-no-form-pjax"],
               "submit, data-form, form does not exist, data-pjax": [
@@ -803,6 +804,14 @@ describe("yii", function () {
                 '<input name="bar" value="2" type="hidden" data-yii-action-helper="true">' +
                 "</form>",
             ],
+            'data-method="post", data-href, data-params': [
+              ".post-data-href",
+              '<form method="post" action="/tests/index" style="display: none;">' +
+                '<input name="_csrf" value="foobar" type="hidden">' +
+                '<input name="foo" value="1" type="hidden" data-yii-action-helper="true">' +
+                '<input name="bar" value="2" type="hidden" data-yii-action-helper="true">' +
+                "</form>",
+            ],
           },
           function (elementSelector, expectedFormHtml) {
             it("should create temporary form and submit it", function () {
@@ -917,6 +926,17 @@ describe("yii", function () {
                 '<input name="bar" value="2" type="hidden" data-yii-action-helper="true">' +
                 "</form>",
             ],
+            "data-form, invalid href, valid data-href, new method, data-params":
+              [
+                ".bad-href-data-href-new-method",
+                "#method-form",
+                '<form id="method-form" method="post" action="/tests/index">' +
+                  '<input name="query" value="a">' +
+                  '<input name="_csrf" value="foobar" type="hidden" data-yii-action-helper="true">' +
+                  '<input name="foo" value="1" type="hidden" data-yii-action-helper="true">' +
+                  '<input name="bar" value="2" type="hidden" data-yii-action-helper="true">' +
+                  "</form>",
+              ],
             "data-form, new action, put method, data-params": [
               ".new-action-put-method",
               "#method-form",


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
