### PR TITLE
feat: make `yii.js` `clickableSelector` and `changeableSelector` runtime updates rebind delegated `data-method`/`data-confirm` handlers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: include triggering attribute metadata in per-field `yiiActiveForm` Ajax validation requests.
 - feat: allow `yii.js` `handleAction` to use `data-href` with `data-method` when `href` is missing or invalid.
 - feat: add namespaced aliases for `yiiGridView` `beforeFilter` and `afterFilter` events while preserving legacy subscriptions.
-- fix: make `yii.js` `clickableSelector` and `changeableSelector` runtime updates rebind delegated data-method/data-confirm handlers.
+- feat: make `yii.js` `clickableSelector` and `changeableSelector` runtime updates rebind delegated `data-method`/`data-confirm` handlers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: include triggering attribute metadata in per-field `yiiActiveForm` Ajax validation requests.
 - feat: allow `yii.js` `handleAction` to use `data-href` with `data-method` when `href` is missing or invalid.
 - feat: add namespaced aliases for `yiiGridView` `beforeFilter` and `afterFilter` events while preserving legacy subscriptions.
+- fix: make `yii.js` `clickableSelector` and `changeableSelector` runtime updates rebind delegated data-method/data-confirm handlers.

--- a/src/assets/yii.js
+++ b/src/assets/yii.js
@@ -35,6 +35,13 @@
  */
 // eslint-disable-next-line max-statements
 window.yii = (function ($) {
+  var dataMethodsEventNamespace = ".yii.dataMethods";
+  var clickableSelector =
+    'a, button, input[type="submit"], input[type="button"], input[type="reset"], ' +
+    'input[type="image"]';
+  var changeableSelector = "select, input, textarea";
+  var isDataMethodsInitialized = false;
+
   var pub = {
     /**
      * List of JS or CSS URLs that can be loaded multiple times via AJAX requests.
@@ -49,13 +56,11 @@ window.yii = (function ($) {
     /**
      * The selector for clickable elements that need to support confirmation and form submission.
      */
-    clickableSelector:
-      'a, button, input[type="submit"], input[type="button"], input[type="reset"], ' +
-      'input[type="image"]',
+    clickableSelector: clickableSelector,
     /**
      * The selector for changeable elements that need to support confirmation and form submission.
      */
-    changeableSelector: "select, input, textarea",
+    changeableSelector: changeableSelector,
 
     /**
      * @return string|undefined the CSRF parameter name. Undefined is returned if CSRF validation is not enabled.
@@ -233,6 +238,50 @@ window.yii = (function ($) {
     "target",
   ];
   var actionHelperAttribute = "data-yii-action-helper";
+  defineDataMethodsSelectorProperties();
+
+  function defineDataMethodsSelectorProperties() {
+    Object.defineProperties(pub, {
+      clickableSelector: {
+        configurable: true,
+        enumerable: true,
+        get: function () {
+          return clickableSelector;
+        },
+        set: function (value) {
+          if (clickableSelector === value) {
+            return;
+          }
+
+          clickableSelector = value;
+          rebindDataMethods();
+        },
+      },
+      changeableSelector: {
+        configurable: true,
+        enumerable: true,
+        get: function () {
+          return changeableSelector;
+        },
+        set: function (value) {
+          if (changeableSelector === value) {
+            return;
+          }
+
+          changeableSelector = value;
+          rebindDataMethods();
+        },
+      },
+    });
+  }
+
+  function rebindDataMethods() {
+    if (!isDataMethodsInitialized) {
+      return;
+    }
+
+    bindDataMethodsHandlers();
+  }
 
   function createActionContext($e, event) {
     var $form = $e.attr("data-form")
@@ -616,22 +665,37 @@ window.yii = (function ($) {
   }
 
   function initDataMethods() {
-    var handler = function (event) {
-      var actionData = getDataMethodActionData($(this));
-      if (shouldSkipDataMethod(actionData)) {
-        return true;
-      }
+    isDataMethodsInitialized = true;
+    bindDataMethodsHandlers();
+  }
 
-      executeDataMethodAction(this, actionData, event);
-      event.stopImmediatePropagation();
-
-      return false;
-    };
-
+  function bindDataMethodsHandlers() {
     // handle data-confirm and data-method for clickable and changeable elements
     $(document)
-      .on("click.yii", pub.clickableSelector, handler)
-      .on("change.yii", pub.changeableSelector, handler);
+      .off("click" + dataMethodsEventNamespace)
+      .off("change" + dataMethodsEventNamespace)
+      .on(
+        "click" + dataMethodsEventNamespace,
+        pub.clickableSelector,
+        handleDataMethodEvent,
+      )
+      .on(
+        "change" + dataMethodsEventNamespace,
+        pub.changeableSelector,
+        handleDataMethodEvent,
+      );
+  }
+
+  function handleDataMethodEvent(event) {
+    var actionData = getDataMethodActionData($(this));
+    if (shouldSkipDataMethod(actionData)) {
+      return true;
+    }
+
+    executeDataMethodAction(this, actionData, event);
+    event.stopImmediatePropagation();
+
+    return false;
   }
 
   function handleScriptAjaxPrefilter(options, xhr, loadedScripts) {

--- a/tests/js/tests/yii.test.js
+++ b/tests/js/tests/yii.test.js
@@ -1823,6 +1823,13 @@ describe("yii", function () {
     var yiiConfirmSpy;
     var yiiHandleActionStub;
     var extraEventHandlerSpy;
+    var defaultClickableSelector;
+    var defaultChangeableSelector;
+
+    before(function () {
+      defaultClickableSelector = yii.clickableSelector;
+      defaultChangeableSelector = yii.changeableSelector;
+    });
 
     beforeEach(function () {
       windowConfirmStub = sinon.stub(window, "confirm", function () {
@@ -1839,6 +1846,11 @@ describe("yii", function () {
     });
 
     afterEach(function () {
+      yii.clickableSelector = defaultClickableSelector;
+      yii.changeableSelector = defaultChangeableSelector;
+      $(".custom-clickable-element").remove();
+      $(".custom-changeable-wrapper").remove();
+
       windowConfirmStub.restore();
       yiiConfirmSpy.restore();
       yiiHandleActionStub.restore();
@@ -1922,6 +1934,39 @@ describe("yii", function () {
       });
     });
 
+    describe("with updated clickableSelector", function () {
+      it("should rebind click handling to the new selector", function () {
+        var event = $.Event("click");
+        var customElementId = "data-methods-custom-click-confirm";
+
+        yii.clickableSelector = ".custom-clickable-element";
+
+        $("#data-methods-click-confirm").trigger($.Event("click"));
+
+        assert.isFalse(yiiConfirmSpy.called);
+        assert.isFalse(yiiHandleActionStub.called);
+        assert.isTrue(extraEventHandlerSpy.calledOnce);
+
+        $(".data-methods").append(
+          '<a id="' +
+            customElementId +
+            '" class="data-methods-element custom-clickable-element" href="/tests/index" data-confirm="Are you sure?"></a>',
+        );
+
+        $("#" + customElementId).trigger(event);
+
+        assert.isTrue(yiiConfirmSpy.calledOnce);
+        assert.equal(yiiConfirmSpy.getCall(0).thisValue.id, customElementId);
+
+        assert.isTrue(yiiHandleActionStub.calledOnce);
+        assert.equal(
+          yiiHandleActionStub.getCall(0).args[0].attr("id"),
+          customElementId,
+        );
+        assert.strictEqual(yiiHandleActionStub.getCall(0).args[1], event);
+      });
+    });
+
     describe("with changeableSelector without data-confirm", function () {
       var elementId = "data-methods-change";
       var $element;
@@ -1951,6 +1996,44 @@ describe("yii", function () {
         assert.strictEqual(yiiHandleActionStub.getCall(0).args[1], event);
 
         assert.isFalse(extraEventHandlerSpy.called);
+      });
+    });
+
+    describe("with updated changeableSelector", function () {
+      it("should rebind change handling to the new selector", function () {
+        var event = $.Event("change");
+        var customElementId = "data-methods-custom-change";
+
+        yii.changeableSelector = ".custom-changeable-element";
+
+        $("#data-methods-change").val(1);
+        $("#data-methods-change").trigger($.Event("change"));
+
+        assert.isFalse(yiiConfirmSpy.called);
+        assert.isFalse(yiiHandleActionStub.called);
+        assert.isTrue(extraEventHandlerSpy.calledOnce);
+
+        $(".data-methods").append(
+          '<form class="custom-changeable-wrapper">' +
+            '<select id="' +
+            customElementId +
+            '" class="data-methods-element custom-changeable-element" data-method="get">' +
+            '<option value="1">html</option>' +
+            '<option value="2">css</option>' +
+            "</select>" +
+            "</form>",
+        );
+
+        $("#" + customElementId).val(1);
+        $("#" + customElementId).trigger(event);
+
+        assert.isFalse(yiiConfirmSpy.called);
+        assert.isTrue(yiiHandleActionStub.calledOnce);
+        assert.equal(
+          yiiHandleActionStub.getCall(0).args[0].attr("id"),
+          customElementId,
+        );
+        assert.strictEqual(yiiHandleActionStub.getCall(0).args[1], event);
       });
     });
   });


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
