### PR TITLE
fix: re-run `yiiActiveForm` submit validation on subsequent submits after successful `_blank` target submission.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: allow `yii.js` `handleAction` to use `data-href` with `data-method` when `href` is missing or invalid.
 - feat: add namespaced aliases for `yiiGridView` `beforeFilter` and `afterFilter` events while preserving legacy subscriptions.
 - feat: make `yii.js` `clickableSelector` and `changeableSelector` runtime updates rebind delegated `data-method`/`data-confirm` handlers.
+- fix: re-run `yiiActiveForm` submit validation on subsequent submits after successful `_blank` target submission.

--- a/src/assets/yii.activeForm.js
+++ b/src/assets/yii.activeForm.js
@@ -624,6 +624,9 @@
           return false;
         }
         updateHiddenButton($form);
+        if (shouldResetValidatedAfterSubmit($form, data.submitObject)) {
+          data.validated = false;
+        }
         return true; // continue submitting the form since validation passes
       } else {
         // First submit's call (from yii.js/handleAction) - execute validating
@@ -896,6 +899,21 @@
   };
 
   var buttonOptions = ["action", "target", "method", "enctype"];
+
+  var shouldResetValidatedAfterSubmit = function ($form, $button) {
+    var target = "";
+    if ($button && $button.length) {
+      target = $button.attr("formtarget") || target;
+    }
+    if (!target) {
+      target = $form.attr("target");
+    }
+    if (!target) {
+      return false;
+    }
+
+    return String(target).toLowerCase() !== "_self";
+  };
 
   /**
    * Returns current form options

--- a/tests/js/tests/yii.activeForm.test.js
+++ b/tests/js/tests/yii.activeForm.test.js
@@ -170,6 +170,62 @@ describe("yii.activeForm", function () {
       });
     });
 
+    it("should re-run validation on next submit after successful submit with formtarget _blank", function () {
+      var validateCalls = 0;
+      var $firstField = $(".field-test-att1");
+
+      $activeForm = $("#w4");
+      $activeForm.yiiActiveForm("destroy");
+      $firstField.removeClass("has-error has-success");
+      $firstField.find(".field-error").empty();
+      $activeForm.yiiActiveForm(
+        [
+          {
+            id: "test-att1",
+            input: "#test-att1",
+            container: ".field-test-att1",
+            validate: function (attribute, value, messages) {
+              validateCalls += 1;
+              if (value === "") {
+                messages.push("Att1 cannot be blank.");
+              }
+            },
+          },
+        ],
+        {
+          errorCssClass: "has-error",
+          successCssClass: "has-success",
+        },
+      );
+
+      var $submitButton = $(
+        '<button type="submit" name="scenario" value="create" formtarget="_blank"></button>',
+      );
+      $activeForm.append($submitButton);
+      $activeForm.data("yiiActiveForm").submitObject = $submitButton;
+
+      var submitStub = sinon.stub($.fn, "submit", function () {
+        this.triggerHandler("submit");
+        return this;
+      });
+
+      try {
+        $("#test-att1").val("valid");
+        var firstSubmitResult = $activeForm.triggerHandler("submit");
+        assert.isFalse(firstSubmitResult);
+        assert.strictEqual(validateCalls, 1);
+        assert.isFalse($activeForm.data("yiiActiveForm").validated);
+
+        $("#test-att1").val("");
+        var secondSubmitResult = $activeForm.triggerHandler("submit");
+        assert.isFalse(secondSubmitResult);
+        assert.strictEqual(validateCalls, 2);
+        assert.isTrue($firstField.hasClass("has-error"));
+      } finally {
+        submitStub.restore();
+      }
+    });
+
     describe("with disabled fields", function () {
       var inputTypes = {
         test_radio: "radioList",


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
